### PR TITLE
Fix batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# email-generator-command
+
+A PHP command line tool to generate fake email addresses.
+
+## Installation
+https://getcomposer.org/download
+https://getcomposer.org/doc/00-intro.md#globally
+
+``` git clone git@github.com:davidrushton/email-generator-command.git ```
+
+``` cd email-generator-command ```
+
+``` composer install ```
+
+## Usage:
+
+```php generate emails {total} {filename} --batch={chunk}```
+
+e.g. ```php generate emails 1000``` will generate 1000 fake emails
+
+

--- a/src/GenerateEmailsCommand.php
+++ b/src/GenerateEmailsCommand.php
@@ -41,7 +41,7 @@ class GenerateEmailsCommand extends Command {
         $batch = $input->getOption('batch');
 
         $emails = $this->makeEmails($total);
-        $this->saveEmails($emails, $filename);
+        $this->saveEmails($emails, $filename, $batch);
 
         $output->writeln('Complete - Generated '.$total.' emails');
     }


### PR DESCRIPTION
Batch is now passed in as a parameter. Previously it wasn’t passed in,
so was always null.